### PR TITLE
fix: Wasm ESM integration error

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -17,6 +17,7 @@
     "@vitejs/plugin-vue": "4.3.3",
     "typescript": "5.1.6",
     "vite": "4.4.9",
+    "vite-plugin-wasm": "^3.3.0",
     "vue-tsc": "1.8.8"
   }
 }

--- a/playground/pnpm-lock.yaml
+++ b/playground/pnpm-lock.yaml
@@ -12,7 +12,7 @@ dependencies:
 optionalDependencies:
   rusty-vue-compiler:
     specifier: file:../crates/wasm/pkg/
-    version: link:../crates/wasm/pkg
+    version: file:../crates/wasm/pkg
 
 devDependencies:
   '@babel/types':
@@ -27,6 +27,9 @@ devDependencies:
   vite:
     specifier: 4.4.9
     version: 4.4.9
+  vite-plugin-wasm:
+    specifier: ^3.3.0
+    version: 3.3.0(vite@4.4.9)
   vue-tsc:
     specifier: 1.8.8
     version: 1.8.8(typescript@5.1.6)
@@ -520,6 +523,14 @@ packages:
     hasBin: true
     dev: true
 
+  /vite-plugin-wasm@3.3.0(vite@4.4.9):
+    resolution: {integrity: sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5
+    dependencies:
+      vite: 4.4.9
+    dev: true
+
   /vite@4.4.9:
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -586,3 +597,10 @@ packages:
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
+
+  file:../crates/wasm/pkg:
+    resolution: {directory: ../crates/wasm/pkg, type: directory}
+    name: vue-compiler-wasm
+    requiresBuild: true
+    dev: false
+    optional: true

--- a/playground/src/components/Playground.vue
+++ b/playground/src/components/Playground.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue'
-import init, {baseCompile} from 'rusty-vue-compiler'
-await init()
+import { baseCompile } from 'rusty-vue-compiler'
 
 let input = ref('<p>Hello World from wasm!</p>')
 let output = ref('')
@@ -9,14 +8,13 @@ let output = ref('')
 watchEffect(async () => {
   output.value = baseCompile(input.value)
 })
-
 </script>
 
 <template>
-    <div class="playground">
-      <textarea v-model="input"/>
-      <code v-html="output"/>
-    </div>
+  <div class="playground">
+    <textarea v-model="input" />
+    <code v-html="output" />
+  </div>
 </template>
 
 <style scoped>

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import wasm from 'vite-plugin-wasm'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/vue-compiler/',
-  plugins: [vue()],
+  plugins: [wasm(),vue()],
   server: {
     fs: {
       // Allow serving files from one level up to the project root


### PR DESCRIPTION
I got this error when `pnpm run dev` on playground

> "ESM integration proposal for Wasm" is not supported currently. Use vite-plugin-wasm or other community plugins to handle this. Alternatively, you can use `.wasm?init` or `.wasm?url`. See https://vitejs.dev/guide/features.html#webassembly for more details.

<img width="1278" alt="スクリーンショット 2024-01-07 17 12 02" src="https://github.com/HerringtonDarkholme/vue-compiler/assets/71201308/532dfeb3-6a1d-4efd-a2e2-f298abde8d69">

and fixed by configuring [vite-plugin-wasm](https://github.com/Menci/vite-plugin-wasm)


https://github.com/HerringtonDarkholme/vue-compiler/assets/71201308/d80c63f1-f7a6-4fee-8517-5964c8d4a1ab

