### PR TITLE
fix: readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
 <a href="https://rustwasm.github.io/wasm-pack/"><img src="https://raw.githubusercontent.com/HerringtonDarkholme/vue-compiler/main/playground/src/assets/wasm-ferris.png" alt="WebAssembly ferris" width="317"></a>
- <a href="https://github.com/vuejs/vue-next"><img src="https://raw.githubusercontent.com/HerringtonDarkholme/vue-compiler/main/playground/src/assets/logo.png" alt="Vue" width="200"></a>
+ <a href="https://github.com/vuejs/core"><img src="https://raw.githubusercontent.com/HerringtonDarkholme/vue-compiler/main/playground/src/assets/logo.png" alt="Vue" width="200"></a>
 </p>
 
 <p align="center"><a href="https://herringtondarkholme.github.io/vue-compiler/">Try it out in the wasm playground!</a></p>
@@ -35,8 +35,8 @@ No support since most features in full build are additional except for browser b
 
 ## Reference
 
-* [vue-next](https://github.com/vuejs/vue-next): ご本家様
+* [vuejs/core](https://github.com/vuejs/core): ご本家様
 * [html spec](https://html.spec.whatwg.org/multipage/parsing.html) is the definitive guide for parsing HTML-like files.
-* [Vue Template Explorer](https://vue-next-template-explorer.netlify.app/) gives instant results for  code generation and error reporting.
+* [Vue Template Explorer](https://template-explorer.vuejs.org/) gives instant results for  code generation and error reporting.
 * [Nu html checker](https://validator.w3.org/nu/#textarea) is the official html validator from W3C. This is the canonical error reporter for html parsing, when there is a discrepancy between the framework and the spec.
 * [AST explorer](https://astexplorer.net/) can inspect AST nodes interactively.

--- a/crates/compiler/src/converter/convert_element.rs
+++ b/crates/compiler/src/converter/convert_element.rs
@@ -204,10 +204,10 @@ fn should_use_block<'a>(e: &Element<'a>, tag: &Js<'a>) -> bool {
         }
     }
     // <svg> and <foreignObject> must be forced into blocks so that block
-    // updates inside get proper isSVG flag at runtime. (vue-next/#639, #643)
+    // updates inside get proper isSVG flag at runtime. (vuejs/core/#639, #643)
     // Technically web-specific, but splitting out of core is too complex
     e.tag_name == "svg" || e.tag_name == "foreignObject" ||
-    // vue-next/#938: elements with dynamic keys should be forced into blocks
+    // vuejs/core/#938: elements with dynamic keys should be forced into blocks
     prop_finder(e, "key").dynamic_only().find().is_some()
 }
 

--- a/crates/compiler/src/converter/mod.rs
+++ b/crates/compiler/src/converter/mod.rs
@@ -3,7 +3,7 @@ IR Converter module takes AST and produces intermediate representation.
 All core template syntax conversion happens here. IR is later used for
 optimizing transformation and code generation. As we decouple codegen
 node from AST, Vue's transformation passes are broken down to two parts.
-Convert module roughly corresponds to following transform in vue-next.
+Convert module roughly corresponds to following transform in vuejs/core.
 
 # IR Convert
 * transformElement

--- a/crates/compiler/src/parser.rs
+++ b/crates/compiler/src/parser.rs
@@ -740,7 +740,7 @@ impl<'a, 'b> DirectiveParser<'a, 'b> {
         }
         let remain = &prefixed[1..];
         // bind/on/customDir accept arg, mod. slot accepts nothing.
-        // see vuejs/vue-next#1241 special case for v-slot
+        // see vuejs/core#1241 special case for v-slot
         if is_v_slot {
             if prefixed.starts_with(MOD_CHAR) {
                 // only . can end dir_name, e.g. v-slot.error

--- a/crates/compiler/src/transformer/mod.rs
+++ b/crates/compiler/src/transformer/mod.rs
@@ -1,6 +1,6 @@
 /*!
 Transform IRNode.
-This module contains the canonical transformations from vue-next and
+This module contains the canonical transformations from vuejs/core and
 the original ones for the parity of features not implemented in Convert.
 
 ## Canonical

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # Architecture
 
-The original design in [vue-next](https://github.com/vuejs/vue-next/blob/master/packages/compiler-core/src/ast.ts) mixes
+The original design in [vuejs/core](https://github.com/vuejs/core/blob/main/packages/compiler-core/src/ast.ts) mixes
 code generation and ast parsing in the same data structure. As we can see, the transform pass will in-place mutate ast nodes,
 leaving the node with both code generation node and ssr code generation node.
 
@@ -33,8 +33,8 @@ The compilation has several phases:
 
 ## Other Design different from the original compiler
 * Directive parsing is implemented manually instead of by regexp.
-* [`nodeTransforms`](https://github.com/vuejs/vue-next/blob/642710ededf51f1e57286496ab0a64a4d27be800/packages/compiler-core/src/options.ts#L174) is not supported. It's too hard for app creator to use and maintain IR invariants. Platform devs can still customize by implementing converter/transformer.
-* [`directiveTransforms`](https://github.com/vuejs/vue-next/blob/642710ededf51f1e57286496ab0a64a4d27be800/packages/compiler-core/src/options.ts#L179) now can returns not only `Props` but also `SimpleExpression`. The extra flexibility makes a more cohesive v-bind/v-on conversion: the logic for processing the directives now resides in one single file without regard to the presence of an argument.
+* [`nodeTransforms`](https://github.com/vuejs/core/blob/642710ededf51f1e57286496ab0a64a4d27be800/packages/compiler-core/src/options.ts#L174) is not supported. It's too hard for app creator to use and maintain IR invariants. Platform devs can still customize by implementing converter/transformer.
+* [`directiveTransforms`](https://github.com/vuejs/core/blob/642710ededf51f1e57286496ab0a64a4d27be800/packages/compiler-core/src/options.ts#L179) now can returns not only `Props` but also `SimpleExpression`. The extra flexibility makes a more cohesive v-bind/v-on conversion: the logic for processing the directives now resides in one single file without regard to the presence of an argument.
 * Runtime helper collection `context.helper/helperString` is moved out from convert and tracked in transform phase, avoiding several methods and reducing HashMap to a bitflag.
 
 


### PR DESCRIPTION
The redirect is working, so there's no issue with navigation, but the link was a bit outdated, so I've corrected it.
(I've changed the word 'vue-next' to 'vuejs/core').